### PR TITLE
Improved build time for app container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,16 @@ RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz \
   && python -m pip install --upgrade pip setuptools wheel virtualenv
 
 ## Copy app files
+COPY ./requirements.txt /
+
+## Install dependencies
+RUN pip install -r requirements.txt
+
+## Copy app files
 COPY ./ /app
 
 ## Install dependencies
 RUN cd /app \
-  && pip install -r requirements.txt \
   && python setup.py develop \
   && cd /
+


### PR DESCRIPTION
## New behavior
File `requirements.txt` is now copied to container and packages are installed via `pip` _before_ the rest of the application files are copied. This means that after an image was built for the first time, on subsequent builds Python dependencies only have to be reinstalled whenever the requirements change. Any other changes in the application code will only require installation of the application itself. This reduces the build time from >12 seconds to <3 seconds (tested on VM at CSC/Finland) in these cases.